### PR TITLE
Чинит 24 час в продолжительности трека

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,15 +15,7 @@ module.exports = (config) => {
         return music.parseFile(path)
             .then(metadata => {
                 const duration = parseFloat(metadata.format.duration);
-                const date = new Date(null).setSeconds(Math.ceil(duration));
-
-                return new Intl.DateTimeFormat('en', {
-                    hour: 'numeric',
-                    minute: 'numeric',
-                    second: 'numeric',
-                    hourCycle: 'h23'
-                    timeZone: 'UTC',
-                }).format(date);
+                return new Date(Math.ceil(duration) * 1000).toISOString().substr(11, 8)
             })
             .catch(error => {
                 console.log(error);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,7 @@ module.exports = (config) => {
                     hour: 'numeric',
                     minute: 'numeric',
                     second: 'numeric',
-                    hour12: false,
+                    hourCycle: 'h23'
                     timeZone: 'UTC',
                 }).format(date);
             })

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,11 +11,10 @@ module.exports = (config) => {
     });
 
     const getDuration = (path) => {
-
         return music.parseFile(path)
             .then(metadata => {
                 const duration = parseFloat(metadata.format.duration);
-                return new Date(Math.ceil(duration) * 1000).toISOString().substr(11, 8)
+                return new Date(Math.ceil(duration) * 1000).toISOString().substr(11, 8);
             })
             .catch(error => {
                 console.log(error);


### PR DESCRIPTION
>Вадим Макеев, [10.10.20 20:05]
Чат, помогайте. У нас фид Веб-стандартов взбесился: вместо 00:59:12 выводит 24:59:12. Дело в функции `getDuration`
 или в том, какие данные она получает от пакета music-metadata. Если кто умный, помогите отладить? :)
Например, 249-й выпуск: <itunes:duration>24:59:12</itunes:duration>
Как только выпуск длиннее часа — всё нормально: <itunes:duration>01:08:25</itunes:duration>
Описание бага: https://stackoverflow.com/a/60887094/7214336