### PR TITLE
Исправляет ссылки на статьи

### DIFF
--- a/src/episodes/295.md
+++ b/src/episodes/295.md
@@ -53,8 +53,8 @@ permalink: false
 
 - [Stay alert](https://dev.to/richharris/stay-alert-d)
 - [Foundations](https://adactio.com/journal/18337)
-- [Breaking the web forward](https://adactio.com/journal/18337)
-- [Choice Words about the upcoming deprecation of JS dialogs](https://adactio.com/journal/18337)
+- [Breaking the web forward](https://www.quirksmode.org/blog/archives/2021/08/breaking_the_we.html)
+- [Choice Words about the upcoming deprecation of JS dialogs](https://css-tricks.com/choice-words-about-the-upcoming-deprecation-of-javascript-dialogs/)
 
 ## IE пошёл к бабуле
 


### PR DESCRIPTION
Привет. 

Мне кажется, ссылки на статьи: "Breaking the web forward", "Choice Words about the upcoming deprecation of JS dialogs" сломаны. 

Предложенные варианты могут не соответствовать задумке автора. 